### PR TITLE
Move token extract logic to SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.0"
+          go-version: "1.21.0"
           check-latest: true
       - name: Verify
         run: |

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,16 +11,15 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	"github.com/Azure/checkaccess-v2-go-sdk/client/internal/test"
 	"github.com/google/go-cmp/cmp"
-)
 
-var (
-	endpoint = "https://westus.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview"
-	scope    = "https://authorization.azure.net/.default"
+	"github.com/Azure/checkaccess-v2-go-sdk/client/internal"
+	"github.com/Azure/checkaccess-v2-go-sdk/client/internal/test"
 )
 
 func TestClientCreate(t *testing.T) {
+	endpoint := "https://westus.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview"
+	scope := "https://authorization.azure.net/.default"
 	emptyString := "   "
 	cred, err := azidentity.NewClientSecretCredential("888988bf-86f1-31ea-91cd-2d7cd011db48", "clientID", "clientSecret", nil)
 	if err != nil {
@@ -74,6 +73,8 @@ func TestClientCreate(t *testing.T) {
 
 func TestCheckAccess(t *testing.T) {
 	t.Parallel()
+	endpoint := "https://westus.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview"
+
 	cases := []struct {
 		desc             string
 		returnedHttpCode int
@@ -94,7 +95,7 @@ func TestCheckAccess(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {
-			mockPipeline := test.CreatePipelineWithServer(tt.returnedHttpCode)
+			mockPipeline := internal.CreatePipelineWithServer(tt.returnedHttpCode)
 			client := &remotePDPClient{endpoint, mockPipeline}
 			decision, err := client.CheckAccess(context.Background(), AuthorizationRequest{})
 			if decision != tt.expectedDecision && err != tt.expectedErr {
@@ -107,6 +108,8 @@ func TestCheckAccess(t *testing.T) {
 
 func TestCreateAuthorizationRequest(t *testing.T) {
 	t.Parallel()
+	endpoint := "https://westus.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview"
+	scope := "https://authorization.azure.net/.default"
 	actionInfo := []ActionInfo{{Id: "read"}, {Id: "write"}}
 	actions := []string{"read", "write"}
 	dummyObjectId := "1234567890"
@@ -123,7 +126,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 
 	for _, tt := range []struct {
 		name                     string
-		claims                   *test.Custom
+		claims                   *internal.Custom
 		wantAuthorizationRequest *AuthorizationRequest
 		wantErr                  string
 	}{
@@ -133,7 +136,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 		},
 		{
 			name: "pass - don't set claimName or groups when both exist",
-			claims: &test.Custom{
+			claims: &internal.Custom{
 				ObjectId: dummyObjectId,
 				ClaimNames: map[string]interface{}{
 					"groups": "src1",
@@ -152,7 +155,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 		},
 		{
 			name: "pass - don't set claimName or groups when both don't exist",
-			claims: &test.Custom{
+			claims: &internal.Custom{
 				ObjectId: dummyObjectId,
 			},
 			wantAuthorizationRequest: &AuthorizationRequest{
@@ -167,7 +170,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 		},
 		{
 			name: "pass - set claimName when claimName exits and groups don't exist",
-			claims: &test.Custom{
+			claims: &internal.Custom{
 				ObjectId: dummyObjectId,
 				ClaimNames: map[string]interface{}{
 					"groups": "src1",
@@ -185,7 +188,7 @@ func TestCreateAuthorizationRequest(t *testing.T) {
 		},
 		{
 			name: "pass - set groups when groups exits and claimName don't exist",
-			claims: &test.Custom{
+			claims: &internal.Custom{
 				ObjectId: dummyObjectId,
 				Groups:   []string{"group1", "group2"},
 			},

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -10,17 +10,17 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/checkaccess-v2-go-sdk/client/internal/test"
 	"github.com/google/go-cmp/cmp"
+)
 
-	testhttp "github.com/Azure/ARO-RP/test/util/http/server"
+var (
+	endpoint = "https://westus.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview"
+	scope    = "https://authorization.azure.net/.default"
 )
 
 func TestClientCreate(t *testing.T) {
-	endpoint := "https://westus.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview"
-	scope := "https://authorization.azure.net/.default"
 	emptyString := "   "
 	cred, err := azidentity.NewClientSecretCredential("888988bf-86f1-31ea-91cd-2d7cd011db48", "clientID", "clientSecret", nil)
 	if err != nil {
@@ -72,7 +72,8 @@ func TestClientCreate(t *testing.T) {
 	}
 }
 
-func TestCallingCheckAccess(t *testing.T) {
+func TestCheckAccess(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		desc             string
 		returnedHttpCode int
@@ -91,68 +92,133 @@ func TestCallingCheckAccess(t *testing.T) {
 			expectedErr:      errors.New("An error"),
 		},
 	}
-	for _, c := range cases {
-		srv, close := testhttp.NewTLSServer()
-		srv.SetResponse(testhttp.WithStatusCode(c.returnedHttpCode))
-		client := createClientWithServer(srv)
-		t.Run(c.desc, func(t *testing.T) {
+	for _, tt := range cases {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockPipeline := test.CreatePipelineWithServer(tt.returnedHttpCode)
+			client := &remotePDPClient{endpoint, mockPipeline}
 			decision, err := client.CheckAccess(context.Background(), AuthorizationRequest{})
-			if decision != c.expectedDecision && err != c.expectedErr {
+			if decision != tt.expectedDecision && err != tt.expectedErr {
 				t.Errorf("expected decision to be %v; and error to be %s. Got %v and %s",
-					c.expectedDecision, c.expectedErr, decision, err)
+					tt.expectedDecision, tt.expectedErr, decision, err)
 			}
 		})
-		close()
 	}
 }
 
 func TestCreateAuthorizationRequest(t *testing.T) {
 	t.Parallel()
-	endpoint := "https://westus.authorization.azure.net/providers/Microsoft.Authorization/checkAccess?api-version=2021-06-01-preview"
-	scope := "https://authorization.azure.net/.default"
+	actionInfo := []ActionInfo{{Id: "read"}, {Id: "write"}}
+	actions := []string{"read", "write"}
+	dummyObjectId := "1234567890"
+	resourceId := "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/vm"
 	cred, err := azidentity.NewClientSecretCredential("888988bf-86f1-31ea-91cd-2d7cd011db48", "clientID", "clientSecret", nil)
 	if err != nil {
 		t.Error("Unable to create a new client secret credential")
 	}
 
-	resourceId := "resource456"
-	subjectAttributes := SubjectAttributes{
-		ObjectId:  "object123",
-		ClaimName: "claim789",
-	}
-	actions := []string{"read", "write"}
-
-	expected := AuthorizationRequest{
-		Subject: SubjectInfo{
-			Attributes: subjectAttributes,
-		},
-		Actions: []ActionInfo{
-			{Id: "read"},
-			{Id: "write"},
-		},
-		Resource: ResourceInfo{
-			Id: resourceId,
-		},
-	}
 	client, err := NewRemotePDPClient(endpoint, scope, cred, nil)
 	if err != nil {
 		t.Error("Unable to create a new PDP client")
 	}
-	result := client.CreateAuthorizationRequest(resourceId, actions, subjectAttributes)
 
-	if diff := cmp.Diff(result, expected); diff != "" {
-		t.Errorf("incorrect authorization request: %v", diff)
-	}
-}
+	for _, tt := range []struct {
+		name                     string
+		claims                   *test.Custom
+		wantAuthorizationRequest *AuthorizationRequest
+		wantErr                  string
+	}{
+		{
+			name:    "fail - invalid token",
+			wantErr: "need token in creating AuthorizationRequest",
+		},
+		{
+			name: "pass - don't set claimName or groups when both exist",
+			claims: &test.Custom{
+				ObjectId: dummyObjectId,
+				ClaimNames: map[string]interface{}{
+					"groups": "src1",
+				},
+				Groups: []string{"group1", "group2"},
+			},
+			wantAuthorizationRequest: &AuthorizationRequest{
+				Subject: SubjectInfo{
+					Attributes: SubjectAttributes{ObjectId: dummyObjectId},
+				},
+				Actions: actionInfo,
+				Resource: ResourceInfo{
+					Id: resourceId,
+				},
+			},
+		},
+		{
+			name: "pass - don't set claimName or groups when both don't exist",
+			claims: &test.Custom{
+				ObjectId: dummyObjectId,
+			},
+			wantAuthorizationRequest: &AuthorizationRequest{
+				Subject: SubjectInfo{
+					Attributes: SubjectAttributes{ObjectId: dummyObjectId},
+				},
+				Actions: actionInfo,
+				Resource: ResourceInfo{
+					Id: resourceId,
+				},
+			},
+		},
+		{
+			name: "pass - set claimName when claimName exits and groups don't exist",
+			claims: &test.Custom{
+				ObjectId: dummyObjectId,
+				ClaimNames: map[string]interface{}{
+					"groups": "src1",
+				},
+			},
+			wantAuthorizationRequest: &AuthorizationRequest{
+				Subject: SubjectInfo{
+					Attributes: SubjectAttributes{ObjectId: dummyObjectId, ClaimName: GroupExpansion},
+				},
+				Actions: actionInfo,
+				Resource: ResourceInfo{
+					Id: resourceId,
+				},
+			},
+		},
+		{
+			name: "pass - set groups when groups exits and claimName don't exist",
+			claims: &test.Custom{
+				ObjectId: dummyObjectId,
+				Groups:   []string{"group1", "group2"},
+			},
+			wantAuthorizationRequest: &AuthorizationRequest{
+				Subject: SubjectInfo{
+					Attributes: SubjectAttributes{ObjectId: dummyObjectId, Groups: []string{"group1", "group2"}},
+				},
+				Actions: actionInfo,
+				Resource: ResourceInfo{
+					Id: resourceId,
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testtoken := ""
+			if tt.claims != nil {
+				testtoken, err = test.CreateTestToken(dummyObjectId, tt.claims)
+				if err != nil {
+					t.Errorf("Error creating test token: %v", err)
+				}
+			}
 
-func createClientWithServer(s *testhttp.Server) RemotePDPClient {
-	return &remotePDPClient{
-		endpoint: s.URL(),
-		pipeline: runtime.NewPipeline(
-			"remotepdpclient_test",
-			"v1.0.0",
-			runtime.PipelineOptions{},
-			&policy.ClientOptions{Transport: s},
-		),
+			result, err := client.CreateAuthorizationRequest(resourceId, actions, testtoken)
+			if tt.wantErr != "" && err == nil {
+				t.Errorf("expected error to be '%s' but got '%s'", tt.wantErr, err)
+			}
+			if tt.wantErr == "" && err != nil {
+				t.Errorf("expected error to be 'nil' but got '%s'", err)
+			}
+			if diff := cmp.Diff(result, tt.wantAuthorizationRequest); diff != "" {
+				t.Errorf("incorrect authorization request: %v", diff)
+			}
+		})
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -95,7 +95,7 @@ func TestCheckAccess(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.desc, func(t *testing.T) {
-			mockPipeline := internal.CreatePipelineWithServer(tt.returnedHttpCode)
+			mockPipeline := test.CreatePipelineWithServer(tt.returnedHttpCode)
 			client := &remotePDPClient{endpoint, mockPipeline}
 			decision, err := client.CheckAccess(context.Background(), AuthorizationRequest{})
 			if decision != tt.expectedDecision && err != tt.expectedErr {

--- a/client/generate.go
+++ b/client/generate.go
@@ -1,8 +1,0 @@
-package client
-
-// Copyright (c) Microsoft Corporation.
-// Licensed under the Apache License 2.0.
-
-//go:generate rm -rf ../../../../../mocks/azureclient/authz/$GOPACKAGE
-//go:generate mockgen -destination=../../../mocks/azureclient/authz/$GOPACKAGE/$GOPACKAGE.go github.com/Azure/ARO-RP/pkg/util/azureclient/authz/$GOPACKAGE RemotePDPClient
-//go:generate goimports -local=github.com/Azure/ARO-RP -e -w ../../../mocks/azureclient/authz/$GOPACKAGE/$GOPACKAGE.go

--- a/client/internal/test/util.go
+++ b/client/internal/test/util.go
@@ -1,0 +1,80 @@
+package test
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type Custom struct {
+	ObjectId   string                 `json:"oid"`
+	ClaimNames map[string]interface{} `json:"_claim_names"`
+	Groups     []string               `json:"groups"`
+	jwt.RegisteredClaims
+}
+
+type mockTransport struct {
+	statusCode int
+}
+
+func CreateTestToken(oid string, fakeClaims *Custom) (string, error) {
+	// Define the signing key
+	signingKey := []byte("test-secret-key")
+
+	// Create the custom claims
+	claims := Custom{
+		ObjectId: oid,
+		ClaimNames: map[string]interface{}{
+			"example_claim": "example_value",
+		},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "test-issuer",
+			Subject:   "test-subject",
+			Audience:  []string{"test-audience"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour * 24)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			ID:        "unique-id",
+		},
+	}
+
+	if fakeClaims != nil {
+		claims = *fakeClaims
+	}
+
+	// Create the token
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	// Sign the token
+	tokenString, err := token.SignedString(signingKey)
+	if err != nil {
+		return "", fmt.Errorf("error signing token: %v", err)
+	}
+
+	return tokenString, nil
+}
+
+func (m *mockTransport) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Header:     make(http.Header),
+	}, nil
+}
+
+func CreatePipelineWithServer(returnedHttpCode int) runtime.Pipeline {
+	return runtime.NewPipeline(
+		"remotepdpclient_test",
+		"v0.1.0",
+		runtime.PipelineOptions{},
+		&policy.ClientOptions{
+			Transport: &mockTransport{
+				statusCode: returnedHttpCode,
+			},
+		})
+}

--- a/client/internal/test/util.go
+++ b/client/internal/test/util.go
@@ -5,31 +5,19 @@ package test
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/golang-jwt/jwt/v4"
+
+	"github.com/Azure/checkaccess-v2-go-sdk/client/internal"
 )
 
-type Custom struct {
-	ObjectId   string                 `json:"oid"`
-	ClaimNames map[string]interface{} `json:"_claim_names"`
-	Groups     []string               `json:"groups"`
-	jwt.RegisteredClaims
-}
-
-type mockTransport struct {
-	statusCode int
-}
-
-func CreateTestToken(oid string, fakeClaims *Custom) (string, error) {
+func CreateTestToken(oid string, fakeClaims *internal.Custom) (string, error) {
 	// Define the signing key
 	signingKey := []byte("test-secret-key")
 
 	// Create the custom claims
-	claims := Custom{
+	claims := internal.Custom{
 		ObjectId: oid,
 		ClaimNames: map[string]interface{}{
 			"example_claim": "example_value",
@@ -58,23 +46,4 @@ func CreateTestToken(oid string, fakeClaims *Custom) (string, error) {
 	}
 
 	return tokenString, nil
-}
-
-func (m *mockTransport) Do(req *http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: m.statusCode,
-		Header:     make(http.Header),
-	}, nil
-}
-
-func CreatePipelineWithServer(returnedHttpCode int) runtime.Pipeline {
-	return runtime.NewPipeline(
-		"remotepdpclient_test",
-		"v0.1.0",
-		runtime.PipelineOptions{},
-		&policy.ClientOptions{
-			Transport: &mockTransport{
-				statusCode: returnedHttpCode,
-			},
-		})
 }

--- a/client/internal/token/token.go
+++ b/client/internal/token/token.go
@@ -1,0 +1,24 @@
+package token
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import "github.com/golang-jwt/jwt/v4"
+
+type custom struct {
+	ObjectId   string                 `json:"oid"`
+	ClaimNames map[string]interface{} `json:"_claim_names"`
+	Groups     []string               `json:"groups"`
+	jwt.RegisteredClaims
+}
+
+// ExtractClaims extracts the "oid", "_claim_names", and "groups" claims from a given access jwtToken and return them as a custom struct
+func ExtractClaims(jwtToken string) (*custom, error) {
+	p := jwt.NewParser(jwt.WithoutClaimsValidation())
+	c := &custom{}
+	_, _, err := p.ParseUnverified(jwtToken, c)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/client/internal/token/token.go
+++ b/client/internal/token/token.go
@@ -3,19 +3,15 @@ package token
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
-import "github.com/golang-jwt/jwt/v4"
-
-type custom struct {
-	ObjectId   string                 `json:"oid"`
-	ClaimNames map[string]interface{} `json:"_claim_names"`
-	Groups     []string               `json:"groups"`
-	jwt.RegisteredClaims
-}
+import (
+	"github.com/Azure/checkaccess-v2-go-sdk/client/internal"
+	"github.com/golang-jwt/jwt/v4"
+)
 
 // ExtractClaims extracts the "oid", "_claim_names", and "groups" claims from a given access jwtToken and return them as a custom struct
-func ExtractClaims(jwtToken string) (*custom, error) {
+func ExtractClaims(jwtToken string) (*internal.Custom, error) {
 	p := jwt.NewParser(jwt.WithoutClaimsValidation())
-	c := &custom{}
+	c := &internal.Custom{}
 	_, _, err := p.ParseUnverified(jwtToken, c)
 	if err != nil {
 		return nil, err

--- a/client/internal/token/token_test.go
+++ b/client/internal/token/token_test.go
@@ -1,0 +1,65 @@
+package token
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/Azure/checkaccess-v2-go-sdk/client/internal/test"
+)
+
+func TestExtractClaims(t *testing.T) {
+	dummyObjectId := "1234567890"
+	validTestToken, err := test.CreateTestToken(dummyObjectId, nil)
+	if err != nil {
+		t.Errorf("Error creating test token: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		token      string
+		wantOid    string
+		wantClaims map[string]interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "Can extract oid from a valid token",
+			token:      validTestToken,
+			wantOid:    dummyObjectId,
+			wantClaims: map[string]interface{}{"example_claim": "example_value"},
+			wantErr:    false,
+		},
+		{
+			name:       "Return an error when given an invalid jwt",
+			token:      "invalid",
+			wantOid:    "",
+			wantClaims: nil,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractClaims(tt.token)
+			t.Log(got, err)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expect an error but got nothing")
+				}
+			} else {
+				if got.ObjectId != tt.wantOid {
+					t.Errorf("Got oid: %q, want %q", got.ObjectId, tt.wantOid)
+				}
+				if diff := cmp.Diff(got.ClaimNames, tt.wantClaims); diff != "" {
+					t.Errorf("Got claimNames: %q, want %q", got.ClaimNames, tt.wantClaims)
+				}
+				if err != nil {
+					t.Errorf("Expect no error but got one")
+				}
+			}
+		})
+	}
+}

--- a/client/internal/types.go
+++ b/client/internal/types.go
@@ -1,0 +1,41 @@
+package internal
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+type Custom struct {
+	ObjectId   string                 `json:"oid"`
+	ClaimNames map[string]interface{} `json:"_claim_names"`
+	Groups     []string               `json:"groups"`
+	jwt.RegisteredClaims
+}
+
+type MockTransport struct {
+	statusCode int
+}
+
+func (m *MockTransport) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Header:     make(http.Header),
+	}, nil
+}
+
+func CreatePipelineWithServer(returnedHttpCode int) runtime.Pipeline {
+	return runtime.NewPipeline(
+		"remotepdpclient_test",
+		"v0.1.0",
+		runtime.PipelineOptions{},
+		&policy.ClientOptions{
+			Transport: &MockTransport{
+				statusCode: returnedHttpCode,
+			},
+		})
+}

--- a/client/internal/types.go
+++ b/client/internal/types.go
@@ -3,10 +3,6 @@ package internal
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 import (
-	"net/http"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/golang-jwt/jwt/v4"
 )
 
@@ -15,27 +11,4 @@ type Custom struct {
 	ClaimNames map[string]interface{} `json:"_claim_names"`
 	Groups     []string               `json:"groups"`
 	jwt.RegisteredClaims
-}
-
-type MockTransport struct {
-	statusCode int
-}
-
-func (m *MockTransport) Do(req *http.Request) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: m.statusCode,
-		Header:     make(http.Header),
-	}, nil
-}
-
-func CreatePipelineWithServer(returnedHttpCode int) runtime.Pipeline {
-	return runtime.NewPipeline(
-		"remotepdpclient_test",
-		"v0.1.0",
-		runtime.PipelineOptions{},
-		&policy.ClientOptions{
-			Transport: &MockTransport{
-				statusCode: returnedHttpCode,
-			},
-		})
 }

--- a/go.mod
+++ b/go.mod
@@ -5,19 +5,21 @@ go 1.21
 toolchain go1.22.8
 
 require (
-	github.com/Azure/ARO-RP v0.0.0-20241015143517-37e6171df994
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.15.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/go-cmp v0.6.0
 )
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,3 @@
-github.com/Azure/ARO-RP v0.0.0-20241015143517-37e6171df994 h1:8wCJm1b0G/bzPrGGoLkYB96UZWDZqadkEv+wSyKaNoE=
-github.com/Azure/ARO-RP v0.0.0-20241015143517-37e6171df994/go.mod h1:wgH/cvezrVOQproqqw8a05E+28JYO9JPemJetDeXLhw=
-github.com/Azure/azure-sdk-for-go v63.1.0+incompatible h1:yNC7qlSUWVF8p0TzxdmWW1FJ3DdIA+0Pge41IU/2+9U=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.15.0 h1:eXzkOEXbSTOa7cJ7EqeCVi/OFi/ppDrUtQuttCWy74c=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.15.0/go.mod h1:YL1xnZ6QejvQHWJrX/AvhFl4WW4rqHVoKspWNVwFk0M=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0 h1:B/dfvscEQtew9dVuoxqxrUKKv8Ih2f55PydknDamU+g=
@@ -19,6 +16,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
+github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=


### PR DESCRIPTION
**What does this PR do?**
-  Add helper function to extract `oid`, `_claim_names`, & `groups` from a given JWT token.
- Update func `CreateAuthorizationRequest()` to pass `token` instead of `SubjectAttributes`.
- Refactor unit tests to remove some ARO-RP test util imports.
- Remove `generate.go` file as we don't generate and mocks.

**Testing**
- New Unit tests are added.