### PR TITLE
fix: always return azcore.ResponseError on non-200 responses instead …

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -93,29 +93,20 @@ func (r *remotePDPClient) CheckAccess(ctx context.Context, authzReq Authorizatio
 
 // newCheckAccessError returns an error when non HTTP 200 response is returned.
 func newCheckAccessError(r *http.Response) error {
-	// The checkaccess API returns a plain-text body (e.g. "Too Many Requests") on 429 responses
-	// rather than JSON, so we short-circuit before json.Unmarshal to avoid a parse error.
-	if r.StatusCode == http.StatusTooManyRequests {
-		return &azcore.ResponseError{
-			StatusCode:  r.StatusCode,
-			RawResponse: r,
-			ErrorCode:   fmt.Sprint(http.StatusTooManyRequests),
+	errorCode := fmt.Sprint(r.StatusCode)
+
+	payload, err := runtime.Payload(r)
+	if err == nil {
+		var checkAccessError CheckAccessErrorResponse
+		if json.Unmarshal(payload, &checkAccessError) == nil && checkAccessError.StatusCode != 0 {
+			errorCode = fmt.Sprint(checkAccessError.StatusCode)
 		}
 	}
 
-	payload, err := runtime.Payload(r)
-	if err != nil {
-		return err
-	}
-	var checkAccessError CheckAccessErrorResponse
-	err = json.Unmarshal(payload, &checkAccessError)
-	if err != nil {
-		return err
-	}
 	return &azcore.ResponseError{
 		StatusCode:  r.StatusCode,
 		RawResponse: r,
-		ErrorCode:   fmt.Sprint(checkAccessError.StatusCode),
+		ErrorCode:   errorCode,
 	}
 }
 


### PR DESCRIPTION
…of raw parse errors